### PR TITLE
Fix eventHandler

### DIFF
--- a/src/bg/resolver.js
+++ b/src/bg/resolver.js
@@ -277,7 +277,7 @@ const loadProperties = () => {
         console.log(`Loaded properties: ${JSON.stringify(props)}`)
     })
 }
-chrome.storage.sync.addListener(_ => {
+chrome.storage.onChanged.addListener(_ => {
     console.log(`Loading changed properties...`)
     loadProperties()
 })


### PR DESCRIPTION
There seems to be a syntax issue with the event handler. Noticed that the browser complains about this when the extension is loaded.

Additionally, there seems to be an issue with the blockchain node server as it isn't resolving any new handshake domains, only old ones. I've created a fallback method that relies on resolving the IP from the DNS server (which is still serving up to date information), but this is unideal. You can check that out here https://github.com/kerkkoh/link-frame/commit/f911f5922ecac56595ae7db5475ccda626940602